### PR TITLE
Fix model field name: "save_history" to "save_iterations"

### DIFF
--- a/src/stanrun/cmdline.jl
+++ b/src/stanrun/cmdline.jl
@@ -54,7 +54,7 @@ function cmdline(m::OptimizeModel, id)
             end
         elseif m.algorithm == :newton
             cmd = `$cmd iter=$(m.iter)`
-            if m.save_history
+            if m.save_iterations
                 cmd = `$cmd save_iterations=1`
             else
                 cmd = `$cmd save_iterations=0`


### PR DESCRIPTION
"m.save_history" was not a field name defined in OptimizeModel.jl.  Use 'm.save_iterations" instead.