### PR TITLE
Release/stanoptimize v4 4 4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  CMDSTAN: "/home/worker/cmdstan-2.35.0/"
+  CMDSTAN: "/home/worker/cmdstan-2.37.0/"
 
 jobs:
   test:
@@ -41,17 +41,17 @@ jobs:
           OLDWD=`pwd`
           cd ~
           pwd
-          wget https://github.com/stan-dev/cmdstan/releases/download/v2.35.0/cmdstan-2.35.0.tar.gz
-          tar -xzpf cmdstan-2.35.0.tar.gz
+          wget https://github.com/stan-dev/cmdstan/releases/download/v2.37.0/cmdstan-2.37.0.tar.gz
+          tar -xzpf cmdstan-2.37.0.tar.gz
           ls -lia .
-          ls -lia ./cmdstan-2.35.0
-          ls -lia ./cmdstan-2.35.0/make
-          touch ./cmdstan-2.35.0/make/local
-          echo "STAN_THREADS=true" > ./cmdstan-2.35.0/make/local
+          ls -lia ./cmdstan-2.37.0
+          ls -lia ./cmdstan-2.37.0/make
+          touch ./cmdstan-2.37.0/make/local
+          echo "STAN_THREADS=true" > ./cmdstan-2.37.0/make/local
           make -C $CMDSTAN build
           cd $OLDWD
         env:
-          CMDSTAN: "/home/runner/cmdstan-2.35.0/"
+          CMDSTAN: "/home/runner/cmdstan-2.37.0/"
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
@@ -70,7 +70,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
         env:
-          CMDSTAN: "/home/runner/cmdstan-2.35.0/"
+          CMDSTAN: "/home/runner/cmdstan-2.37.0/"
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.num_threads == 1
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StanOptimize"
 uuid = "fbd8da12-e93d-5a64-9231-612a0707ab99"
 authors = ["Rob J Goedman <goedman@mac.com>"]
-version = "4.4.3"
+version = "4.4.4"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"


### PR DESCRIPTION
Updating CI to use github actions cache v4 as previous versions are deprecated